### PR TITLE
be tolerant to non conforming advertisments

### DIFF
--- a/src/discovery/search.rs
+++ b/src/discovery/search.rs
@@ -478,24 +478,24 @@ impl TryFrom<MulticastResponse> for Response {
         )?;
 
         let date = headers::check_not_empty(
-            response.headers.get(protocol::HEAD_DATE).unwrap(),
-            protocol::HEAD_DATE,
-        )?;
+            response.headers.get(protocol::HEAD_DATE),
+            "Thu, 01 Jan 1970 00:00:00 GMT",
+        );
 
         let location = headers::check_not_empty(
-            response.headers.get(protocol::HEAD_LOCATION).unwrap(),
-            protocol::HEAD_LOCATION,
-        )?;
+            response.headers.get(protocol::HEAD_LOCATION),
+            "http://www.example.org",
+        );
 
         let service_name = headers::check_not_empty(
-            response.headers.get(protocol::HEAD_USN).unwrap(),
-            protocol::HEAD_USN,
-        )?;
+            response.headers.get(protocol::HEAD_USN),
+            "undefined",
+        );
 
         let search_target = headers::check_not_empty(
-            response.headers.get(protocol::HEAD_ST).unwrap(),
-            protocol::HEAD_ST,
-        )?;
+            response.headers.get(protocol::HEAD_ST),
+            "undefined",
+        );
 
         let mut boot_id = 0u64;
         let mut config_id: Option<u64> = None;

--- a/src/utils/headers.rs
+++ b/src/utils/headers.rs
@@ -3,6 +3,7 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+
 pub fn check_required(headers: &HashMap<String, String>, required: &[&str]) -> Result<(), Error> {
     let missing_headers: Vec<String> = required
         .iter()
@@ -62,14 +63,12 @@ pub fn check_empty(header_value: &str, name: &str) -> Result<(), Error> {
     }
 }
 
-pub fn check_not_empty(header_value: &str, name: &str) -> Result<String, Error> {
+pub fn check_not_empty(header_entry: std::option::Option<&String>, default: &str) -> String {
+    let default_value = &default.to_string();
+    let header_value = header_entry.unwrap_or(default_value);
     if !header_value.trim().is_empty() {
-        Ok(header_value.to_string())
+        return header_value.to_string();
     } else {
-        error!(
-            "check_not_empty - header '{}', value '{}' should not be empty",
-            name, header_value
-        );
-        Err(Error::MessageFormat(MessageErrorKind::InvalidFieldValue))
+        return default_value.to_string();
     }
 }


### PR DESCRIPTION
Signed-off-by: mbodmer <marc.bodmer@email.ch>

I have devices not advertising eg. the date. This breaks the current implementation and fails trying to unwrap the Option returning None. This means, as long as I have such a device on my network i cannot use upnp-rs, as it crashes.

I've tried to circumvent this problem in delivering a default value, which is not perfect a all, but better than crashing.